### PR TITLE
Fix double entry problem for initialPickedItems

### DIFF
--- a/lib/multiple_search_selection.dart
+++ b/lib/multiple_search_selection.dart
@@ -784,10 +784,9 @@ class _MultipleSearchSelectionState<T>
     extends State<MultipleSearchSelection<T>> {
   late List<T> showedItems;
   late List<T> allItems;
+  late List<T> pickedItems;
 
   bool showAllItems = false;
-
-  List<T> pickedItems = [];
 
   final GlobalKey _searchFieldKey = GlobalKey();
   final LayerLink _layerLink = LayerLink();
@@ -916,8 +915,10 @@ class _MultipleSearchSelectionState<T>
   }
 
   Future<void> _prepareItems() async {
-    showedItems = [...widget.items ?? []];
+    pickedItems = [...widget.initialPickedItems ?? []];
     allItems = [...widget.items ?? []];
+    allItems.removeWhere((e) => pickedItems.contains(e));
+    showedItems = allItems;
 
     if (widget.sortShowedItems ?? false) {
       showedItems.sort(
@@ -1355,8 +1356,6 @@ class _MultipleSearchSelectionState<T>
     _searchFieldTextEditingController =
         widget.searchField.controller ?? TextEditingController();
     _searchFieldFocusNode = widget.searchField.focusNode ?? FocusNode();
-
-    pickedItems.addAll(widget.initialPickedItems ?? []);
 
     if (widget.isOverlay) {
       _overlayPortalController = OverlayPortalController();


### PR DESCRIPTION
When initialPickedtems is set these Items are not removed from allItems. Because of this these Items can be added again to pickedItems and if they are removed from pickedItems they are added to allItems. This leads to various double entry problems. 